### PR TITLE
fix some core bugs with linting, fill tool and history

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,4 +1,4 @@
-module.exports = [
+export default [
   {
     ignores: ["dist/**", "node_modules/**"],
   },

--- a/src/core/history.ts
+++ b/src/core/history.ts
@@ -1,28 +1,28 @@
 // This function is incharge of the history keeper, .redo, .undo
 
 export function createHistory(canvas: HTMLCanvasElement, ctx: CanvasRenderingContext2D) {
-  let undoSnapshot: ImageData | null = null;
-  let redoSnapshot: ImageData | null = null;
+  let undoSnapshots: ImageData[] = [];
+  let redoSnapshots: ImageData[] = [];
 
   function saveState() {
     const image = ctx.getImageData(0, 0, canvas.width, canvas.height);
-    undoSnapshot = image;
-    redoSnapshot = null;
+    undoSnapshots.push(image);
+    redoSnapshots = [];
   }
   function undo() {
-    if (!undoSnapshot) return;
+    if (undoSnapshots.length === 0) return;
     const current = ctx.getImageData(0, 0, canvas.width, canvas.height);
-    redoSnapshot = current;
-    ctx.putImageData(undoSnapshot, 0, 0);
-    undoSnapshot = null;
+    redoSnapshots.push(current);
+    const prev = undoSnapshots.pop()!;
+    ctx.putImageData(prev, 0, 0);
   }
 
   function redo() {
-    if (!redoSnapshot) return;
+    if (redoSnapshots.length === 0) return;
     const current = ctx.getImageData(0, 0, canvas.width, canvas.height);
-    undoSnapshot = current;
-    ctx.putImageData(redoSnapshot, 0, 0);
-    redoSnapshot = null;
+    undoSnapshots.push(current);
+    const next = redoSnapshots.pop()!;
+    ctx.putImageData(next, 0, 0);
   }
 
   return {

--- a/src/core/renderer.ts
+++ b/src/core/renderer.ts
@@ -31,6 +31,9 @@ export function createRenderer(ctx: CanvasRenderingContext2D, history: any, hook
     pointerHandlers() {
       return {
         down(p: any) {
+          if (currentTool && currentTool.modifiesCanvas !== false) {
+            history.saveState();
+          }
           interaction = [clonePointer(p)];
           toolInstance?.onDown(p, { ctx });
         },
@@ -53,7 +56,6 @@ export function createRenderer(ctx: CanvasRenderingContext2D, history: any, hook
           toolInstance?.onUp(p, { ctx });
 
           if (currentTool && currentTool.modifiesCanvas !== false) {
-            history.saveState();
             hooks.onCommit?.({
               tool: currentTool.name,
               config: currentTool.config,

--- a/src/tools/fill.ts
+++ b/src/tools/fill.ts
@@ -24,7 +24,7 @@ export const fillTool = defineTool({
         const next = parseCssColor(config.color ?? "#000");
         const tolerance = Math.max(0, config.tolerance ?? 0);
 
-        if (colorsMatch(target, next, 0)) return;
+        if (colorsMatch(target, next, tolerance)) return;
 
         const stack: Array<[number, number]> = [[x, y]];
 


### PR DESCRIPTION
fixed the eslint config cuz it was crashing builds by using module.exports
also fixed an infinite loop in the fill tool that happenes when you use tolerance. finally fixed the undo history since it was saving the state after you draw instad of before, so undo actually works now. also made it so you can undo multiple times instead of just once